### PR TITLE
Admin pages for managing blog posts and users

### DIFF
--- a/src/app/admin/posts/columns.tsx
+++ b/src/app/admin/posts/columns.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { ColumnDef } from '@tanstack/react-table';
+import { BadgeAlert, BadgeCheckIcon, MoreHorizontal } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { BlogStory, Post } from '@/types/blog';
+import { User } from '@/types/user';
+import PostDrawer from '@/app/admin/posts/post';
+import Story from '@/app/admin/posts/story';
+
+export const columns: ColumnDef<Post>[] = [
+  {
+    id: 'select',
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+  },
+  {
+    accessorKey: 'title',
+    header: 'Title',
+    cell: ({ row }) => {
+      return <PostDrawer item={row.original} />;
+    },
+    enableHiding: false,
+  },
+  {
+    accessorKey: 'tags',
+    header: 'Tags',
+  },
+  {
+    accessorKey: 'author',
+    header: () => <div>Author</div>,
+    cell: ({ row }) => {
+      const author = row.getValue('author') as User;
+
+      return (
+        <Badge variant="secondary" className="bg-blue-500 text-white dark:bg-blue-600">
+          <BadgeCheckIcon /> {author.username}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: 'stories',
+    header: () => <div>Stories</div>,
+    cell: ({ row }) => {
+      const stories = row.getValue('stories') as BlogStory[];
+
+      return <Story stories={stories} />;
+    },
+  },
+  {
+    accessorKey: 'views',
+    header: 'Views',
+  },
+  {
+    accessorKey: 'publishedAt',
+    header: 'Published',
+    cell: ({ row }) => {
+      const published = row.getValue('publishedAt');
+      if (!published) {
+        return (
+          <Badge variant="secondary" className="bg-red-500 text-white dark:bg-red-600">
+            <BadgeAlert size={'icon'} /> unpublished
+          </Badge>
+        );
+      }
+      return (
+        <Badge variant="secondary" className="bg-blue-500 text-white dark:bg-blue-600">
+          <BadgeCheckIcon /> {published}
+        </Badge>
+      );
+    },
+  },
+  {
+    id: 'actions',
+    cell: ({ row }) => {
+      const payment = row.original;
+
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="h-8 w-8 p-0">
+              <span className="sr-only">Open menu</span>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+            <DropdownMenuItem onClick={() => navigator.clipboard.writeText(payment.id.toString())}>
+              Copy user ID
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>View Post</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant="destructive">Delete Post</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    },
+  },
+];

--- a/src/app/admin/posts/data-table.tsx
+++ b/src/app/admin/posts/data-table.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+
+  return (
+    <div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -1,0 +1,26 @@
+import { columns } from './columns';
+import { DataTable } from './data-table';
+import prisma from '@/services/prisma';
+import { getSession } from '@/lib/session';
+import { redirect } from 'next/navigation';
+import PostDrawer from '@/app/admin/posts/post';
+
+export default async function Page() {
+  const session = await getSession();
+  if (!session?.user?.isAdmin) {
+    return redirect('/');
+  }
+
+  const data = await prisma.post.findMany({
+    include: { author: true, stories: true },
+  });
+
+  return (
+    <div className="container mx-auto pb-10">
+      <div className="flex justify-end pb-2">
+        <PostDrawer />
+      </div>
+      <DataTable columns={columns} data={data} />
+    </div>
+  );
+}

--- a/src/app/admin/posts/post.tsx
+++ b/src/app/admin/posts/post.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useIsMobile } from '@/hooks/use-mobile';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button';
+import Form from 'next/form';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import { useActionState } from 'react';
+import { createPost } from '@/app/blog/actions';
+import { BlogPostActionResponse, BlogPostBasicData } from '@/types/blog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { CheckCircle2 } from 'lucide-react';
+
+const initialState: BlogPostActionResponse = {
+  success: false,
+  message: '',
+};
+
+export default function PostDrawer({ item }: { item?: BlogPostBasicData }) {
+  const [state, action, pending] = useActionState(createPost, initialState);
+
+  const isMobile = useIsMobile();
+
+  return (
+    <Drawer direction={isMobile ? 'bottom' : 'right'}>
+      <DrawerTrigger asChild>
+        <Button
+          variant={item?.title ? 'link' : 'default'}
+          className={cn('text-foreground w-fit text-left', item?.title ? 'px-0' : '')}
+        >
+          {item?.title ? item.title : 'Create'}
+        </Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader className="gap-1">
+          <DrawerTitle>{item?.title}</DrawerTitle>
+          <DrawerDescription>Quickly edit your post details</DrawerDescription>
+          {state?.message && (
+            <Alert variant={state.success ? 'default' : 'destructive'}>
+              {state.success && <CheckCircle2 className="h-4 w-4" />}
+              <AlertDescription>{state.message}</AlertDescription>
+            </Alert>
+          )}
+        </DrawerHeader>
+        <div className="flex flex-col gap-4 overflow-y-auto px-4 text-sm">
+          <Form className="flex flex-col gap-4" action={action} id="form">
+            <div className="flex flex-col gap-3">
+              <Label htmlFor="title">Title</Label>
+              <Input
+                id="title"
+                type="text"
+                name="title"
+                defaultValue={item ? item.title : state?.payload?.title}
+              />
+              {state?.errors?.title && (
+                <p id="title-error" className="text-sm text-red-400">
+                  {state.errors.title[0]}
+                </p>
+              )}
+            </div>
+            {item && (
+              <div className="flex flex-col gap-3">
+                <Label htmlFor="slug">Slug</Label>
+                <Input id="slug" defaultValue={item.slug} disabled />
+              </div>
+            )}
+            <div className="flex flex-col gap-3">
+              <Label htmlFor="tags">Tags</Label>
+              <Input
+                id="tags"
+                type="text"
+                name="tags"
+                defaultValue={item ? item.tags : state?.payload?.tags}
+              />
+            </div>
+            <div className="flex flex-col gap-3">
+              <Label htmlFor="summary">Summary</Label>
+              <Textarea
+                id="summary"
+                name="summary"
+                defaultValue={item ? item.summary : state?.payload?.summary}
+              />
+            </div>
+            <input type="hidden" name="slug" defaultValue={item?.slug} />
+          </Form>
+        </div>
+        <DrawerFooter>
+          <Button type="submit" form="form">
+            {item ? (pending ? 'Updating...' : 'Update') : pending ? 'Creating...' : 'Create'}
+          </Button>
+          {/*<DrawerClose asChild>
+            <Button variant="outline">Done</Button>
+          </DrawerClose>*/}
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/app/admin/posts/story.tsx
+++ b/src/app/admin/posts/story.tsx
@@ -1,0 +1,44 @@
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command';
+import { BlogStory } from '@/types/blog';
+import { FileText } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function Story({ stories }: { stories: BlogStory[] }) {
+  const [open, setOpen] = useState(false);
+
+  const click = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setOpen((open) => !open);
+  };
+  return (
+    <>
+      <Button variant="link" className="inline-flex" onClick={click}>
+        <FileText size={16} className="mt-0.5 mr-2" /> {stories.length}
+      </Button>
+      <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandInput placeholder="Type a command or search..." />
+        <CommandList>
+          <CommandEmpty>No results found.</CommandEmpty>
+          <CommandGroup heading="Stories">
+            {stories.map((story, index) => (
+              <CommandItem key={index}>{story.title}</CommandItem>
+            ))}
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Actions"></CommandGroup>
+        </CommandList>
+        <CommandInput placeholder="New Story Title" />
+        <Button>Create</Button>
+      </CommandDialog>
+    </>
+  );
+}

--- a/src/app/admin/users/columns.tsx
+++ b/src/app/admin/users/columns.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { ColumnDef } from '@tanstack/react-table';
+import { BadgeCheckIcon, MoreHorizontal } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { User } from '@/types/user';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+
+export const columns: ColumnDef<User>[] = [
+  {
+    id: 'select',
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+  },
+  {
+    accessorKey: 'username',
+    header: 'Username',
+  },
+  {
+    accessorKey: 'email',
+    header: 'Email',
+  },
+  {
+    accessorKey: 'isAdmin',
+    header: () => <div>Is Admin</div>,
+    cell: ({ row }) => {
+      const formatted = row.getValue('isAdmin') ? 'Admin' : 'User';
+
+      return (
+        <Badge variant="secondary" className="bg-blue-500 text-white dark:bg-blue-600">
+          <BadgeCheckIcon />
+          {formatted}
+        </Badge>
+      );
+    },
+  },
+  {
+    id: 'actions',
+    cell: ({ row }) => {
+      const payment = row.original;
+
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="h-8 w-8 p-0">
+              <span className="sr-only">Open menu</span>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+            <DropdownMenuItem onClick={() => navigator.clipboard.writeText(payment.id.toString())}>
+              Copy user ID
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>View user</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>Delete User</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    },
+  },
+];

--- a/src/app/admin/users/data-table.tsx
+++ b/src/app/admin/users/data-table.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+
+  return (
+    <div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,20 @@
+import { columns } from './columns';
+import { DataTable } from './data-table';
+import prisma from '@/services/prisma';
+import { getSession } from '@/lib/session';
+import { redirect } from 'next/navigation';
+
+export default async function Page() {
+  const session = await getSession();
+  if (!session?.user?.isAdmin) {
+    return redirect('/');
+  }
+
+  const data = await prisma.user.findMany({});
+
+  return (
+    <div className="container mx-auto py-10">
+      <DataTable columns={columns} data={data} />
+    </div>
+  );
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-neutral-200 dark:bg-neutral-200/30 data-[state=checked]:bg-neutral-900 data-[state=checked]:text-neutral-50 dark:data-[state=checked]:bg-neutral-900 data-[state=checked]:border-neutral-900 focus-visible:border-neutral-950 focus-visible:ring-neutral-950/50 aria-invalid:ring-red-500/20 dark:aria-invalid:ring-red-500/40 aria-invalid:border-red-500 size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:dark:bg-neutral-800/30 dark:data-[state=checked]:bg-neutral-50 dark:data-[state=checked]:text-neutral-900 dark:dark:data-[state=checked]:bg-neutral-50 dark:data-[state=checked]:border-neutral-50 dark:focus-visible:border-neutral-300 dark:focus-visible:ring-neutral-300/50 dark:aria-invalid:ring-red-900/20 dark:dark:aria-invalid:ring-red-900/40 dark:aria-invalid:border-red-900",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content bg-white fixed z-50 flex h-auto flex-col dark:bg-neutral-950",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        <div className="bg-neutral-100 mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block dark:bg-neutral-800" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-neutral-950 font-semibold dark:text-neutral-50", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-neutral-500 text-sm dark:text-neutral-400", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-neutral-100/50 border-t font-medium [&>tr]:last:border-b-0 dark:bg-neutral-800/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-neutral-100/50 data-[state=selected]:bg-neutral-100 border-b transition-colors dark:hover:bg-neutral-800/50 dark:data-[state=selected]:bg-neutral-800",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-neutral-950 h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] dark:text-neutral-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-neutral-500 mt-4 text-sm dark:text-neutral-400", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,5 +1,19 @@
 import { User } from '@/types/user';
 
+export interface Post {
+  id: number;
+  title: string;
+  slug: string;
+  summary: string | null;
+  tags: string[];
+  authorId: number;
+  author: User;
+  stories: BlogStory[];
+  views: number;
+  createdAt: Date;
+  publishedAt?: Date | null;
+}
+
 export interface BlogItem {
   id: number;
   title: string;
@@ -17,21 +31,37 @@ export interface BlogItem {
 export interface BlogStory {
   id: number;
   title: string;
-  content: string;
-  file: string;
-  generatedAt: Date;
+  content?: string;
+  file?: string | null | undefined;
+  generatedAt?: Date | null | undefined;
 }
 
-export interface BlogPostData {
+export interface BlogStoryBasicData {
   title: string;
-  tags: string;
+}
+
+export interface BlogPostBasicData {
+  title: string;
+  slug?: string;
+  tags?: string;
   summary: string;
 }
 
-export interface BlogPostActionResponse {
+export interface BlogPostResponse {
   success: boolean;
   message: string;
+}
+
+export interface BlogPostActionResponse extends BlogPostResponse {
   errors?: {
-    [K in keyof BlogPostData]?: string[];
+    [K in keyof BlogPostBasicData]?: string[];
   };
+  payload?: BlogPostBasicData | null;
+}
+
+export interface BlogPostStoryResponse extends BlogPostResponse {
+  errors?: {
+    [K in keyof BlogStoryBasicData]?: string[];
+  };
+  payload?: BlogStoryBasicData | null;
 }


### PR DESCRIPTION
Based on how the blog system is constructed, the first draft of the blog management section will cater to it's specific needs.
I suppose, ideally, we'd want to do this from a single page. However, with how cumbersome forms and state are to develop and maintain without a clear idea of how I want the process to be, I will opt in for this implementation now.

So far, I have your basic crud forms.

![image](https://github.com/user-attachments/assets/d1888f7a-865b-4109-8d1c-2a2c1b0e1acc)

First step is creating the primary entity with the minimum required fields, this is done in an app drawer that opens when 'create' is clicked

![image](https://github.com/user-attachments/assets/a665dcf8-0979-4f48-9b92-2dc3a4690f71)

This creates an unpublished post. Post's cannot be published until a story is created and generated. It will be the final step of the process.

Once we have a post, you can start creating/managing stories.

![image](https://github.com/user-attachments/assets/0a76229b-c28d-4f23-bc5f-7b623c62ce60)

Create a story from the prompt. It adds a story to the list. Click the story and you're taken to an MDX editor to populate the story contents.

Once at least one story is made, the ability to publish will be enabled, allowing the story to be delivered to the end user and populated within the sitemap.

Todo:

- [x] Post List
- [x] Create basic post
- [x] Edit basic post
- [x] Story command prompt
- [ ] Create story
- [ ] Write Story
- [ ] Generate story mdx file
- [ ] Publish post
- [ ] Add story to sitemap

